### PR TITLE
Update 1.20.1 to SVC 1.5.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.3-SNAPSHOT'
+    id 'fabric-loom' version '1.+'
     id 'com.github.johnrengelman.shadow' version '8.1.1'
     id 'com.matthewprenger.cursegradle' version '1.4.0'
     id 'com.modrinth.minotaur' version '2.+'
@@ -20,6 +20,9 @@ repositories {
         content {
             includeGroup 'maven.modrinth'
         }
+    }
+    maven {
+        url 'https://cursemaven.com'
     }
     mavenLocal()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.+'
+    id 'fabric-loom' version '1.6.11'
     id 'com.github.johnrengelman.shadow' version '8.1.1'
     id 'com.matthewprenger.cursegradle' version '1.4.0'
     id 'com.modrinth.minotaur' version '2.+'

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,10 +9,10 @@ loader_version=0.14.21
 
 fabric_version=0.83.0+1.20.1
 
-voicechat_api_version=2.4.0
+voicechat_api_version=2.5.0
 
-voicechat_dependency=1.20.1-2.4.13
-voicechat_breaks=1.20.1-2.5.0
+voicechat_dependency=1.20.1-2.5.13
+voicechat_breaks=1.20.1-2.6.0
 replaymod_dependency=1.20.1-2.6.13
 
 mod_name=Replay Voice Chat

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/de/maxhenkel/replayvoicechat/net/FakeVoicechatConnection.java
+++ b/src/main/java/de/maxhenkel/replayvoicechat/net/FakeVoicechatConnection.java
@@ -52,6 +52,7 @@ public class FakeVoicechatConnection extends ClientVoicechatConnection {
     }
 
     @Override
-    public void sendToServer(NetworkMessage message) throws Exception {
+    public boolean sendToServer(NetworkMessage message) {
+        return true;
     }
 }


### PR DESCRIPTION
This tiny change allows the 1.20.1 version to function on the latest release of Simple Voice Chat.

Since 1.20.1 of SVC is still in active development and a lot of modpacks have already been created for 1.20.1, it sadly can't really be considered an "outdated" version quite yet.

I hate maintaining old versions as much as the next guy, but thankfully this can actually be made significantly easier.  Since the mod dependencies stay absolutely constant across versions, it wouldn't be too difficult to make the build environment completely MC-version agnostic.  I'll even refactor the project for you if you want.

This mod makes recording _so much_ less space-intensive and is such a lifesaver when it comes to video creation, so I want as many people to be able to use it as possible. 😄