### PR TITLE
Add Forge compatibility

### DIFF
--- a/src/main/java/de/maxhenkel/replayvoicechat/ReplayVoicechatPlugin.java
+++ b/src/main/java/de/maxhenkel/replayvoicechat/ReplayVoicechatPlugin.java
@@ -2,12 +2,14 @@ package de.maxhenkel.replayvoicechat;
 
 import de.maxhenkel.replayvoicechat.playback.AudioPlaybackManager;
 import de.maxhenkel.replayvoicechat.recording.VoicechatRecorder;
+import de.maxhenkel.voicechat.api.ForgeVoicechatPlugin;
 import de.maxhenkel.voicechat.api.VoicechatApi;
 import de.maxhenkel.voicechat.api.VoicechatClientApi;
 import de.maxhenkel.voicechat.api.VoicechatPlugin;
 import de.maxhenkel.voicechat.api.events.*;
 import de.maxhenkel.voicechat.plugins.impl.VoicechatClientApiImpl;
 
+@ForgeVoicechatPlugin
 public class ReplayVoicechatPlugin implements VoicechatPlugin {
 
     public static VoicechatClientApi CLIENT_API = VoicechatClientApiImpl.instance();

--- a/src/main/java/de/maxhenkel/voicechat/api/ForgeVoicechatPlugin.java
+++ b/src/main/java/de/maxhenkel/voicechat/api/ForgeVoicechatPlugin.java
@@ -1,0 +1,8 @@
+package de.maxhenkel.voicechat.api;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ForgeVoicechatPlugin {
+}

--- a/src/main/java/de/maxhenkel/voicechat/api/ForgeVoicechatPlugin.java
+++ b/src/main/java/de/maxhenkel/voicechat/api/ForgeVoicechatPlugin.java
@@ -1,8 +1,0 @@
-package de.maxhenkel.voicechat.api;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-
-@Retention(RetentionPolicy.RUNTIME)
-public @interface ForgeVoicechatPlugin {
-}


### PR DESCRIPTION
Yeah yeah it's a Fabric mod, but it absolutely works with the Forge version of SVC too (with Sinytra Connector to use Replay on Forge) as long as it's annotated with the annotation the Forge version expects.  

This is specifically for people who play on a Forge server that enforces the Forge version of SVC (and thus can't use the Fabric version), but who _also_ want to use Replay Mod, so they install the Connector and record a ton of replays only to realize that none of them have voice chat and are thus completely useless.  Not that I would have any experience with that. >->

Anyway, this PR just adds the Forge entrypoint to the mod (shading the annotation class to avoid classloading issues on non-Forge versions), making it fully compatible with the Forge version of Simple Voice Chat without _any_ major refactoring or compatibility concerns. :D